### PR TITLE
Added default Access-Control-Allow-Origin headers for CORS

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -81,6 +81,7 @@ standardHeaders =
   'Pragma': 'no-cache'
   'Expires': 'Fri, 01 Jan 1990 00:00:00 GMT'
   'X-Content-Type-Options': 'nosniff'
+  'Access-Control-Allow-Origin': '*'
 
   # Gmail also sends this, though I'm not really sure what it does...
 #  'X-Xss-Protection': '1; mode=block'


### PR DESCRIPTION
Since this is something that has been asked for I'm sending you a simple cross origin default header.
This will allow cross origin requests from \* by default which probably isn't a big deal.
This could probably also be handled by some middleware like https://github.com/antono/connect-cors but this is pretty simple to handle here.
