### PR TITLE
Fix the fs.watchFile issue in a Windows platform

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -327,14 +327,22 @@ catch e
 
 # This is mostly to help development, but if the client is recompiled, I'll pull in a new version.
 # This isn't tested by the unit tests - but its not a big deal.
-fs.watchFile clientFile, persistent: false, (curr, prev) ->
-  if curr.mtime.getTime() != prev.mtime.getTime()
-    # Putting a synchronous file call here will stop the whole server while the client is reloaded.
-    # Again, this will only happen during development so its not a big deal.
-    console.log "Reloading client JS"
-    clientCode = fs.readFileSync clientFile, 'utf8'
-    clientStats = curr
-
+if process.platform is "win32"
+  fs.watch clientFile, persistent: false, (event, filename) ->
+    if event is "change"
+      # Putting a synchronous file call here will stop the whole server while the client is reloaded.
+      # Again, this will only happen during development so its not a big deal.
+      console.log "Reloading client JS"
+      clientCode = fs.readFileSync clientFile, 'utf8'
+      clientStats = curr
+else
+  fs.watchFile clientFile, persistent: false, (curr, prev) ->
+    if curr.mtime.getTime() isnt prev.mtime.getTime()
+      # Putting a synchronous file call here will stop the whole server while the client is reloaded.
+      # Again, this will only happen during development so its not a big deal.
+      console.log "Reloading client JS"
+      clientCode = fs.readFileSync clientFile, 'utf8'
+      clientStats = curr
 
 # ---
 #


### PR DESCRIPTION
fs.watchFile in a Windows platform throws an exception (see here: https://github.com/joyent/node/blob/master/lib/fs.js)

The code switches to fs.watch if it's a Windows platform. It's not a bullet proof version, but at least makes browserchannel work in Windows (tested in node v0.6.6).
# Known issues
- fs.watch fires twice
# Possible improvements
- Also check node.js version, to support backward compatibility (fs.watch does not exist in 0.4.x version or older)
