### PR TITLE
Escape unparseable characters before sending JSON over the wire.

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -740,6 +740,11 @@ module.exports = browserChannel = (options, onConnect) ->
             data = ([id, data] for {id, data} in arrays)
             bytes = JSON.stringify(data) + "\n"
 
+            # Stand back, pro hax! Ideally there is a general solution for escaping these characters
+            # when converting to JSON.
+            bytes = bytes.replace(/\u2028/g, "\\u2028")
+            bytes = bytes.replace(/\u2029/g, "\\u2029")
+
             # **Away!**
             backChannel.methods.write bytes
             backChannel.bytesSent += bytes.length

--- a/test/server.coffee
+++ b/test/server.coffee
@@ -666,6 +666,17 @@ module.exports = testCase
         test.deepEqual data, [[0, ['c', @session.id, null, 8]], [1, testData]]
         test.done()
 
+  'The server escapes tricky characters before sending JSON over the wire': (test) ->
+    testData = {'a': 'hello\u2028\u2029there\u2028\u2029'}
+    @onSession = (@session) =>
+      @session.send testData
+
+    # I'm not using @connect because we need to know about the response to the first POST.
+    @post '/channel/bind?VER=8&RID=1000&t=1', 'count=0', (res) =>
+      readLengthPrefixedString res, (data) =>
+        test.deepEqual data, """[[0,["c","#{@session.id}",null,8]],[1,{"a":"hello\\u2028\\u2029there\\u2028\\u2029"}]]\n"""
+        test.done()
+
   'The server buffers data if no backchannel is available': (test) -> @connect ->
     testData = ['hello', 'there', null, 1000, {}, [], [555]]
 


### PR DESCRIPTION
Hey,

We made a couple of specific solutions for unparseable characters (u2028 and u2029) in BC. It seems that some browsers have issues parsing JSON strings with these characters in them.

There's a bit more info here: http://stackoverflow.com/questions/2965293/javascript-parse-error-on-u2028-unicode-character

Ideally a more general solution to exclude a range of problematic characters would be better, but it's a start.

Cheers

Josh & James

P.S. In debugging this issue we broke your ShareJS demo site by simply pasting one of these characters in...sorry :)
