### PR TITLE
Removed timeout from channelHandleArray.

### DIFF
--- a/lib/bcsocket.coffee
+++ b/lib/bcsocket.coffee
@@ -168,11 +168,8 @@ BCSocket = (url, options) ->
 
   # Messages from the server are passed directly.
   handler.channelHandleArray = (channel, message) ->
-    # Exceptions thrown in channelHandleArray aren't handled well at all.
-    try
-      self['onmessage']? message
-    catch e
-      setTimeout (-> throw e), 0
+    # Exceptions thrown in channelHandleArray aren't handled at all.
+    self['onmessage']? message
 
   # This reconnects if the current session is null.
   reconnect = ->


### PR DESCRIPTION
Hiding errors in a timeout wipes out the stack which makes debugging terribly difficult.
Errors that are caught here may be thrown from applications that use browserchannel.

Twice now in two days I have run into errors raised from my application that were swallowed by this try/catch and timeout. By re-raising the error in a timeout I get no stack information in the debugger.
