### PR TITLE
disable fs.watch when in production

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -340,25 +340,27 @@ catch e
   console.error 'Could not load the client javascript. Run `cake client` to generate it.'
   throw e
 
-# This is mostly to help development, but if the client is recompiled, I'll pull in a new version.
-# This isn't tested by the unit tests - but its not a big deal.
-#
-# The `readFileSync` call here will stop the whole server while the client is reloaded.
-# This will only happen during development so its not a big deal.
-if process.platform is "win32"
-  # Windows doesn't support watchFile. See:
-  # https://github.com/josephg/node-browserchannel/pull/6
-  fs.watch clientFile, persistent: false, (event, filename) ->
-    if event is "change"
-      console.log "Reloading client JS"
-      clientCode = fs.readFileSync clientFile, 'utf8'
-      clientStats = curr
-else
-  fs.watchFile clientFile, persistent: false, (curr, prev) ->
-    if curr.mtime.getTime() isnt prev.mtime.getTime()
-      console.log "Reloading client JS"
-      clientCode = fs.readFileSync clientFile, 'utf8'
-      clientStats = curr
+
+  # This is mostly to help development, but if the client is recompiled, I'll pull in a new version.
+  # This isn't tested by the unit tests - but its not a big deal.
+  #
+  # The `readFileSync` call here will stop the whole server while the client is reloaded.
+  # This will only happen during development so its not a big deal.
+if process.env.NODE_ENV != 'production'
+  if process.platform is "win32"
+    # Windows doesn't support watchFile. See:
+    # https://github.com/josephg/node-browserchannel/pull/6
+    fs.watch clientFile, persistent: false, (event, filename) ->
+      if event is "change"
+        console.log "Reloading client JS"
+        clientCode = fs.readFileSync clientFile, 'utf8'
+        clientStats = curr
+  else
+    fs.watchFile clientFile, persistent: false, (curr, prev) ->
+      if curr.mtime.getTime() isnt prev.mtime.getTime()
+        console.log "Reloading client JS"
+        clientCode = fs.readFileSync clientFile, 'utf8'
+        clientStats = curr
 
 # ---
 #


### PR DESCRIPTION
I have disabled fs.watch when NODE_ENV 
is production as explained in the comments
this is only useful during development.

And it is giving me some problems when 
deploying to azure.
