### PR TITLE
Rethrow exception

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -678,6 +678,7 @@ module.exports = browserChannel = (options, onConnect) ->
                   message = JSON.parse map.JSON
                 catch e
                   session.close 'Invalid JSON'
+                  return
                 session.emit 'message', message
         else
           # We have data.json. We'll just emit it directly.


### PR DESCRIPTION
If a ShareJS auth function throws an exception,
the following stack is present:
- auth function
- useragent
- session
- EventEmitter
- BC server
- ...

By not re-throwing the exception at this point any exceptions
thrown between the session message event handler and the ShareJS
auth function are swallowed at this point.

With this change exceptions thrown in the auth function are propagated
upwards to the global exception handler.
