### PR TITLE
correct mocha compiler flag for coffeescript >= 1.6

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
---compilers coffee:coffee-script
+--compilers coffee:coffee-script/register
 --reporter spec
 --ui tdd
 --check-leaks


### PR DESCRIPTION
Test suite [passes on Travis](https://travis-ci.org/wenzowski/node-browserchannel/builds/19168552) but [not locally](https://gist.github.com/wenzowski/9088218).

Is the potentially a known issue? Happy to debug.
