### PR TITLE
add travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A [BrowserChannel](http://closure-library.googlecode.com/svn/trunk/closure/goog/net/browserchannel.js) server.
+A [BrowserChannel](http://closure-library.googlecode.com/svn/trunk/closure/goog/net/browserchannel.js) server. [![Build Status](https://travis-ci.org/josephg/node-browserchannel.svg?branch=master)](https://travis-ci.org/josephg/node-browserchannel)
 
 **tldr;** Its like socket.io, but it scales better and it has fewer bugs. It
 just does long polling. It also doesn't support websockets and doesn't support


### PR DESCRIPTION
having travis logs for passing builds is helpful when we need a quick time warp to find out which node, npm, and deps a revision's test suite was passing correctly with

having the badge on the readme might help as a reminder when remote deps differ from local deps

your call @josephg 
