### PR TITLE
Fix tests for node 0.12 and io.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ script: "npm test"
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "iojs"

--- a/test/server.coffee
+++ b/test/server.coffee
@@ -48,7 +48,7 @@ createServer = (opts, method, callback) ->
 
   # Calling server.listen() without a port lets the OS pick a port for us. I don't
   # know why more testing frameworks don't do this by default.
-  server = http.createServer(app).listen ->
+  server = http.createServer(app).listen undefined, '127.0.0.1', ->
     # Obviously, we need to know the port to be able to make requests from the server.
     # The callee could check this itself using the server object, but it'll always need
     # to know it, so its easier pulling the port out here.


### PR DESCRIPTION
In node 0.12 `server.listen()` binds to an IPv6 address when the hostname is not specified.
This patch makes the server bind to `127.0.0.1` so this [assertion](https://github.com/josephg/node-browserchannel/blob/96985069b966f8dc16e7b4d912e32e334fa9d5d5/test/server.coffee#L579) does not fails.