### PR TITLE
Allow setting options.cors to a function in order to set Origin dynamically

### DIFF
--- a/test/server.coffee
+++ b/test/server.coffee
@@ -348,6 +348,14 @@ suite 'server', ->
         server.close()
         done()
 
+  test 'CORS headers can be set using a function', (done) ->
+    createServer cors: (-> 'something'), (->), (server, port) ->
+      http.get {path:'/channel/test?VER=8&MODE=init', host: 'localhost', port: port}, (response) ->
+        assert.strictEqual response.headers['access-control-allow-origin'], 'something'
+        buffer response
+        server.close()
+        done()
+
   test 'CORS header is set on the backchannel response', (done) ->
     server = port = null
 
@@ -361,7 +369,7 @@ suite 'server', ->
         req.abort()
         server.close()
         done()
-    
+
     createServer cors:'foo.com', corsAllowCredentials:true, sessionCreated, (_server, _port) ->
       [server, port] = [_server, _port]
 


### PR DESCRIPTION
Sometimes it is necessary to set the Access-Control-Allow-Origin header
based on the included request headers, for instance the Origin header.

Currently, this is impossible since the cors option must be specified
as a string ahead of time. This change allows a function to be used
instead, which can compute a new value based on the request/response
pair.