### PR TITLE
Fix dynamic cors setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "mocha",
+    "test": "npm run prepublish && mocha",
     "prepublish": "make dist/server.js"
   },
   "dependencies": {


### PR DESCRIPTION
Unfortunately I missed some cases in my last PR! I added new tests
to ensure that cors headers are correctly sent in all cases and
refactored the internal options interface to ensure this sort of
error is now impossible.

Also included is a change to npm test to ensure that it always
runs against the latest coffeescript code.